### PR TITLE
feat(ios): automatic audio only (minimum bitrate)

### DIFF
--- a/ios/Classes/Players/AVQueuePlayerController.swift
+++ b/ios/Classes/Players/AVQueuePlayerController.swift
@@ -39,7 +39,7 @@ public class AVQueuePlayerController: NSObject, PlayerController, AVPlayerViewCo
             }
             peakBitRateController.setAudioOnlyMode(false)
         } else {
-            audioOnlyTimer = Timer.scheduledTimer(withTimeInterval: 10, repeats: false) { _ in
+            audioOnlyTimer = Timer.scheduledTimer(withTimeInterval: 6, repeats: false) { _ in
                 self.peakBitRateController.setAudioOnlyMode(true)
             }
         }

--- a/ios/Classes/Utils/PeakBitrateController.swift
+++ b/ios/Classes/Utils/PeakBitrateController.swift
@@ -1,0 +1,42 @@
+import AVKit
+import Foundation
+
+public class PeakBitrateController {
+    private var requestedPeakBitrate: Double = 0
+    private var audioOnlyMode: Bool = false
+    var playerCurrentItemObserver: NSKeyValueObservation?
+
+    let player: AVPlayer
+    init(player: AVPlayer) {
+        self.player = player
+        playerCurrentItemObserver = player.observe(\.currentItem, options: [.new, .old], changeHandler: { _, change in
+            if change.newValue != nil {
+                self.updateInternalValue()
+            }
+        })
+    }
+
+    func value() -> Double {
+        return requestedPeakBitrate
+    }
+
+    func setAudioOnlyMode(_ v: Bool) {
+        audioOnlyMode = v
+        updateInternalValue()
+    }
+
+    func setPeakBitrate(_ v: Double) {
+        requestedPeakBitrate = v
+        updateInternalValue()
+    }
+
+    private func updateInternalValue() {
+        if audioOnlyMode {
+            debugPrint("bccm: Setting preferredPeakBitRate to 1 (Audio only)")
+            player.currentItem?.preferredPeakBitRate = 1
+        } else {
+            debugPrint("bccm: Setting preferredPeakBitRate to \(requestedPeakBitrate).")
+            player.currentItem?.preferredPeakBitRate = requestedPeakBitrate
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for creating a PR!
To make it easier for reviewers and everyone else to understand your PR, please add some relevant content to the headings below.
Feel free to delete sections that you don't think are relevant.
-->

<!--
About the changes
- What are they and why are they being introduced? 
- If the changes are visual, consider adding screenshots or steps to see the changes.
- Write "Closes #issue" if this PR has an issue it closes.
--> 
## About the changes
I always thought ios did this automatically. Apparently not (I checked with xcode's network profiler).
This mimicks the behavior we already have on Android: https://github.com/bcc-code/bccm-player/blob/15b09173621a8190c35462f44620ffb49f22ba8a/android/src/main/kotlin/media/bcc/bccm_player/players/exoplayer/ExoPlayerController.kt#L79
Whenever the app is not rendering any video (no `currentViewController`), this start a 6s timer (just to not overreact when switching screens etc), then sets `preferredPeakBitrate` to 1 bit/s (0 means auto)

I've checked the network requests, and this is working now.

<!--
Discussion points
- Anything about the PR you'd like to discuss? Got any questions or doubts?
-->
## Discussion points
This isn't true audio only, but it drops down to the lowest quality which is a whole lot better than nothing.
As far as I've researched, there's no way to drop the video track completely without a local proxy or server-side changes.