### PR TITLE
fix: dont pip if player.volume is 0

### DIFF
--- a/android/src/main/kotlin/media/bcc/bccm_player/views/FlutterExoPlayerView.kt
+++ b/android/src/main/kotlin/media/bcc/bccm_player/views/FlutterExoPlayerView.kt
@@ -44,7 +44,7 @@ class FlutterExoPlayerView(
     private var setupDone = false
     override val isFullscreen = false
     override val shouldPipAutomatically
-        get() = pipOnLeave && (playerController?.player?.isPlaying ?: false)
+        get() = pipOnLeave && (playerController?.player?.isPlaying ?: false) && (playerController?.player?.volume?.toDouble() ?: 0.0) > 0
 
     class Factory(private val plugin: BccmPlayerPlugin?) :
         PlatformViewFactory(StandardMessageCodec.INSTANCE) {


### PR DESCRIPTION
Ref https://github.com/bcc-code/bcc-connect-live/issues/122

Tested and worked on bcc media (i added a mute button locally), so should work on live as well.