### PR TITLE
fix(android): enable offline video playback with local files

### DIFF
--- a/android/src/main/kotlin/media/bcc/bccm_player/players/exoplayer/ExoPlayerController.kt
+++ b/android/src/main/kotlin/media/bcc/bccm_player/players/exoplayer/ExoPlayerController.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.TrackGroup
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
@@ -57,7 +58,7 @@ class ExoPlayerController(
             DefaultMediaSourceFactory(context).setDataSourceFactory(
                 CacheDataSource.Factory()
                     .setCache(Downloader.getCache(context))
-                    .setUpstreamDataSourceFactory(DefaultHttpDataSource.Factory())
+                    .setUpstreamDataSourceFactory(DefaultDataSource.Factory(context))
                     .setCacheWriteDataSinkFactory(null)
             )
         )


### PR DESCRIPTION
## About the changes
This PR fixes offline video playback support on Android by updating the upstream data source factory in ExoPlayerController.
Problem: The player was previously using DefaultHttpDataSource.Factory(), which only supports HTTP/HTTPS URLs. This prevented playback of locally cached or downloaded videos using file:// URLs, breaking offline functionality.
Solution: Replace DefaultHttpDataSource.Factory() with DefaultDataSource.Factory(context) which supports multiple protocols including:
HTTP/HTTPS URLs (existing functionality)
Local file:// URLs (new offline support)
Content:// URLs
Asset:// URLs
This change enables the player to handle both online streaming and offline cached/downloaded content seamlessly.

###  Important files
android/src/main/kotlin/media/bcc/bccm_player/players/exoplayer/ExoPlayerController.kt - Updated upstream data source factory to support local files

## Discussion points
This is a critical fix for applications that require offline video playback capabilities. The change is backward compatible and doesn't affect existing HTTP streaming functionality while adding support for local file playback.
Testing: Verify that both HTTP streaming and local file:// playback work correctly after this change.
