### PR TITLE
Fix: Resolve RepeatMode name conflict with newer Flutter versions

### DIFF
--- a/lib/bccm_player_native.dart
+++ b/lib/bccm_player_native.dart
@@ -4,7 +4,7 @@ import 'package:bccm_player/src/native/root_pigeon_playback_listener.dart';
 import 'package:bccm_player/src/native/chromecast_pigeon_listener.dart';
 import 'package:bccm_player/src/pigeon/playback_platform_pigeon.g.dart';
 import 'package:bccm_player/src/state/state_playback_listener.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' hide RepeatMode;
 
 import 'bccm_player.dart';
 

--- a/lib/src/state/player_controller.dart
+++ b/lib/src/state/player_controller.dart
@@ -1,5 +1,5 @@
 import 'package:bccm_player/src/queue/queue_controller.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' hide RepeatMode;
 import 'package:meta/meta.dart';
 import 'package:state_notifier/state_notifier.dart';
 import 'package:collection/collection.dart';


### PR DESCRIPTION
About the changes
This PR fixes a build error caused by a name conflict between the package's RepeatMode and the RepeatMode class recently introduced in the Flutter SDK (specifically in widgets.dart).

<img width="942" height="122" alt="Captura de pantalla 2026-02-15 a la(s) 11 28 04 a m" src="https://github.com/user-attachments/assets/594db332-7fd5-47ee-a529-fbfc57eaa46b" />

Changes introduced:

Updated imports in lib/src/state/player_controller.dart and lib/bccm_player_native.dart.

Added hide RepeatMode to package:flutter/widgets.dart to resolve the ambiguity.

This ensures the package compiles correctly on newer versions of Flutter without breaking existing functionality.

Important files
lib/src/state/player_controller.dart

lib/bccm_player_native.dart

Discussion points
No breaking changes.

This fix is necessary for anyone building with the latest Flutter stable/beta channels.